### PR TITLE
Redirect trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,6 @@ For Excel downloads to work you need to have your storage linked.
 
 ## Usage
 
+If you are using Dependency Injection to inject your models into controller methods, for example, you will need to apply the `CanBeRedirected` trait to the model.  This trait overrides the `resolveRouteBinding()` method and checks for a redirect in the Spatie `MissingPageRedirector` package if the model is not found, before returning a 404.
+
 Enjoy!

--- a/README.md
+++ b/README.md
@@ -10,6 +10,6 @@ For Excel downloads to work you need to have your storage linked.
 
 ## Usage
 
-If you are using Dependency Injection to inject your models into controller methods, for example, you will need to apply the `CanBeRedirected` trait to the model.  This trait overrides the `resolveRouteBinding()` method and checks for a redirect in the Spatie `MissingPageRedirector` package if the model is not found, before returning a 404.
+If you are using Dependency Injection to inject your models into controller methods, for example, you will need to apply the `ShouldRedirectMissingPages` trait to the model.  This trait overrides the `resolveRouteBinding()` method and checks for a redirect in the Spatie `MissingPageRedirector` package if the model is not found, before returning a 404.
 
 Enjoy!

--- a/src-php/Traits/CanBeRedirected.php
+++ b/src-php/Traits/CanBeRedirected.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Dewsign\NovaToolRedirects\Traits;
+
+trait CanBeRedirected
+{
+    /**
+     * Retrieve the model for a bound value.
+     *
+     * @param  mixed  $value
+     * @return \Illuminate\Database\Eloquent\Model|null
+     */
+    public function resolveRouteBinding($value)
+    {
+        $redirectResponse = app(\Spatie\MissingPageRedirector\MissingPageRouter::class)->getRedirectFor(request());
+
+        return $this->where($this->getRouteKeyName(), $value)->first() ?? abort($redirectResponse) ?? abort(404);
+    }
+}

--- a/src-php/Traits/CanBeRedirected.php
+++ b/src-php/Traits/CanBeRedirected.php
@@ -12,8 +12,14 @@ trait CanBeRedirected
      */
     public function resolveRouteBinding($value)
     {
-        $redirectResponse = app(\Spatie\MissingPageRedirector\MissingPageRouter::class)->getRedirectFor(request());
+        if ($resolved = $this->where($this->getRouteKeyName(), $value)->first()) {
+            return $resolved;
+        }
 
-        return $this->where($this->getRouteKeyName(), $value)->first() ?? abort($redirectResponse) ?? abort(404);
+        if ($redirectResponse = app(\Spatie\MissingPageRedirector\MissingPageRouter::class)->getRedirectFor(request())) {
+            abort($redirectResponse);
+        }
+
+        return abort(404);
     }
 }

--- a/src-php/Traits/ShouldRedirectMissingPages.php
+++ b/src-php/Traits/ShouldRedirectMissingPages.php
@@ -2,7 +2,7 @@
 
 namespace Dewsign\NovaToolRedirects\Traits;
 
-trait CanBeRedirected
+trait ShouldRedirectMissingPages
 {
     /**
      * Retrieve the model for a bound value.


### PR DESCRIPTION
This trait overrides the `resolveRouteBinding()` method and checks for a redirect in the Spatie `MissingPageRedirector` package if the model is not found, before returning a 404.